### PR TITLE
Windows firewall port blocking fix

### DIFF
--- a/firewall/firewall/windows/src/firewall.cpp
+++ b/firewall/firewall/windows/src/firewall.cpp
@@ -105,7 +105,7 @@ Firewall::Status Firewall::addPortToBlacklist(
            << (direction == TrafficDirection::Inbound ? "in" : "out") << "\"";
 
   portstr << (direction == TrafficDirection::Inbound ? "local" : "remote")
-	  << "port=" << port;
+          << "port=" << port;
 
   ProcessOutput proc_output;
   if (!ExecuteProcess(proc_output,
@@ -486,8 +486,8 @@ bool Firewall::ParseFirewallRuleBlock(std::stringstream& stream,
     rule = port_rule;
     return true;
   } else if (direction == TrafficDirection::Outbound &&
-      values["RemotePort"].length() != 0 &&
-      values["RemotePort"].compare("Any") != 0) {
+             values["RemotePort"].length() != 0 &&
+             values["RemotePort"].compare("Any") != 0) {
     // blocking a port
     Protocol protocol;
     if (values["Protocol"].compare("TCP") == 0) {

--- a/firewall/firewall/windows/src/firewall.cpp
+++ b/firewall/firewall/windows/src/firewall.cpp
@@ -103,7 +103,9 @@ Firewall::Status Firewall::addPortToBlacklist(
   std::stringstream rulename, portstr;
   rulename << "name=\"BlockPort" << port
            << (direction == TrafficDirection::Inbound ? "in" : "out") << "\"";
-  portstr << "localport=" << port;
+
+  portstr << (direction == TrafficDirection::Inbound ? "local" : "remote")
+	  << "port=" << port;
 
   ProcessOutput proc_output;
   if (!ExecuteProcess(proc_output,


### PR DESCRIPTION
Fixes issue [#95](https://github.com/trailofbits/osquery-issues/issues/95) by blocking local ports for incoming rules and remote ports for outbound rules.