### PR TITLE
Split santa_events table into santa_allowed and santa_denied.

### DIFF
--- a/santa/CMakeLists.txt
+++ b/santa/CMakeLists.txt
@@ -33,10 +33,17 @@ function(main)
     LIBRARIES ${project_libraries}
   )
 
-  add_osquery_extension_ex("SantaEventsTablePlugin" "table" "santa_events"
-    SOURCES ${project_common_source_files} src/santaeventstable.h src/santaeventstable.cpp
+  add_osquery_extension_ex("SantaAllowedDecisionsTablePlugin" "table" "santa_allowed"
+    SOURCES ${project_common_source_files} src/santadecisionstable.h src/santadecisionstable.cpp
     INCLUDEDIRS "${CMAKE_CURRENT_SOURCE_DIR}/src"
-    MAININCLUDES santaeventstable.h
+    MAININCLUDES santadecisionstable.h
+    LIBRARIES ${project_libraries}
+  )
+
+  add_osquery_extension_ex("SantaDeniedDecisionsTablePlugin" "table" "santa_denied"
+    SOURCES ${project_common_source_files} src/santadecisionstable.h src/santadecisionstable.cpp
+    INCLUDEDIRS "${CMAKE_CURRENT_SOURCE_DIR}/src"
+    MAININCLUDES santadecisionstable.h
     LIBRARIES ${project_libraries}
   )
 endfunction()

--- a/santa/README.md
+++ b/santa/README.md
@@ -1,12 +1,12 @@
 # Santa osquery Extension
 
 [Santa](https://github.com/google/santa/) is an open-source application whitelist/blacklist enforcement solution for macOS.
-This extension for osquery enables the osquery user to read the log of `DENY` events that Santa generated on the host 
-with a table called `santa_events`, and to remotely view and *create* new rules for Santa (with or without the use of a Santa sync server or Upvote server) with a table called `santa_rules`.
+This extension for osquery enables the osquery user to read the log of `DENY` events from the Santa generated log file on the host, 
+with a table called `santa_denied`. It also adds a table called `santa_allowed`, to read the log of `ALLOW` events. Finally, it allows the user to remotely view and *create* new rules for Santa (with or without the use of a Santa sync server or Upvote server) with a table called `santa_rules`.
 
 ## Schema
 
-### santa_events table
+### santa_allowed and santa_denied tables (same schema for each table)
 | Column         | Type | Description                                                         |
 |----------------|------|---------------------------------------------------------------------|
 | timestamp      | TEXT | Event timestamp                                                     |
@@ -32,7 +32,8 @@ The value in the **reason** column determines the meaning of the **shasum** fiel
 
 ### Listing allow and deny events
 ``` sql
-SELECT * FROM santa_events;
+SELECT * FROM santa_denied;
+SELECT * FROM santa_allowed;  -- note: this table will normally have hundreds of thousands of entries
 ```
 
 ### Listing system rules

--- a/santa/src/santa.h
+++ b/santa/src/santa.h
@@ -19,6 +19,11 @@
 #include <list>
 #include <string>
 
+enum SantaDecisionType {
+    kAllowed,
+    kDenied,
+};
+
 struct LogEntry final {
   std::string timestamp;
   std::string application;
@@ -44,5 +49,5 @@ const char* getRuleStateName(RuleEntry::State state);
 RuleEntry::Type getTypeFromRuleName(const char* name);
 RuleEntry::State getStateFromRuleName(const char* name);
 
-bool scrapeSantaLog(LogEntries& response);
+bool scrapeSantaLog(LogEntries& response, SantaDecisionType decision);
 bool collectSantaRules(RuleEntries& response);

--- a/santa/src/santadecisionstable.cpp
+++ b/santa/src/santadecisionstable.cpp
@@ -17,9 +17,9 @@
 #include <osquery/logger.h>
 
 #include "santa.h"
-#include "santaeventstable.h"
+#include "santadecisionstable.h"
 
-osquery::TableColumns SantaEventsTablePlugin::columns() const {
+osquery::TableColumns decisionTablesColumns() {
   // clang-format off
   return {
       std::make_tuple("timestamp",
@@ -41,10 +41,9 @@ osquery::TableColumns SantaEventsTablePlugin::columns() const {
   // clang-format on
 }
 
-osquery::QueryData SantaEventsTablePlugin::generate(
-    osquery::QueryContext& request) {
+osquery::QueryData decisionTablesGenerate(osquery::QueryContext& request, SantaDecisionType decision) {
   LogEntries log_entries;
-  if (!scrapeSantaLog(log_entries)) {
+  if (!scrapeSantaLog(log_entries, decision)) {
     return {};
   }
 
@@ -60,4 +59,22 @@ osquery::QueryData SantaEventsTablePlugin::generate(
   }
 
   return result;
+}
+
+osquery::QueryData SantaAllowedDecisionsTablePlugin::generate(
+    osquery::QueryContext& request) {
+      return decisionTablesGenerate(request, decision);
+}
+
+osquery::QueryData SantaDeniedDecisionsTablePlugin::generate(
+    osquery::QueryContext& request) {
+      return decisionTablesGenerate(request, decision);
+}
+
+osquery::TableColumns SantaAllowedDecisionsTablePlugin::columns() const {
+  return decisionTablesColumns();
+}
+
+osquery::TableColumns SantaDeniedDecisionsTablePlugin::columns() const {
+  return decisionTablesColumns();
 }

--- a/santa/src/santadecisionstable.h
+++ b/santa/src/santadecisionstable.h
@@ -18,8 +18,18 @@
 
 #include <osquery/sdk.h>
 
-class SantaEventsTablePlugin final : public osquery::TablePlugin {
+#include "santa.h"
+
+class SantaAllowedDecisionsTablePlugin final : public osquery::TablePlugin {
  private:
+  static const SantaDecisionType decision = kAllowed;
+  osquery::TableColumns columns() const override;
+  osquery::QueryData generate(osquery::QueryContext& request) override;
+};
+
+class SantaDeniedDecisionsTablePlugin final : public osquery::TablePlugin {
+ private:
+  static const SantaDecisionType decision = kDenied;
   osquery::TableColumns columns() const override;
   osquery::QueryData generate(osquery::QueryContext& request) override;
 };


### PR DESCRIPTION
### Description of the Change

When we changed `santa_events` to return all Santa `DENY` and `ALLOW` actions, we didn't add a way to filter one type of decision from the other. This PR splits the results into two separate tables. 

Also, we broke from the osquery table-naming conventions: this should not have been a table that ended in `_events` because it was not event-driven. It parses Santa's logs. So that is the other justification for this change.

### Alternate Designs

The alternative would have been to add a `DECISION` column to the `santa_events` table, but the reason for not going that route is that there are exponentially more `ALLOW` decisions in the logs than there are `DENY` decisions, and the more common use-case is probably to inspect `DENY` decisions. So, querying `DENY` decisions shouldn't have to incur the performance penalty of spooling all of the `ALLOW` decisions in the Santa logs.

### Benefits

- Fixes issue #30 
- Better conforms to osquery table-naming convention

### Possible Drawbacks

🤷🏻‍♂️

### Verification Process

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

I manually created a Santa log in /var/db/santa/santa.log on a macOS 10.13.6 system, with entries from a semi-recent install of Santa. More testing might be justified, but setting up a Santa rules configuration is a pain.

### Applicable Issues

Issue #30 