### PR TITLE
Enable users to select which extensions to build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,11 @@ endfunction()
 function(ImportExtensions)
   message("Importing extensions from '${CMAKE_CURRENT_SOURCE_DIR}'")
 
+  if (DEFINED ENV{TRAILOFBITS_EXTENSIONS_TO_BUILD})
+    set(extensions_to_build $ENV{TRAILOFBITS_EXTENSIONS_TO_BUILD})
+    string(REPLACE "," ";" extensions_to_build "${extensions_to_build}")
+  endif()
+
   file(GLOB extension_list RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/*")
   foreach(extension ${extension_list})
     if("${extension}" STREQUAL ".vscode")
@@ -67,6 +72,10 @@ function(ImportExtensions)
     endif()
 
     if("${extension}" STREQUAL "libraries" OR "${extension}" STREQUAL ".git")
+      continue()
+    endif()
+
+    if (DEFINED extensions_to_build AND NOT "${extension}" IN_LIST extensions_to_build)
       continue()
     endif()
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ make -j `nproc`
 
 If you see the following warning, it can be ignored: `-- Cannot find Doxygen executable in path`
 
+It's also possible to select which extensions to build, using the TRAILOFBITS_EXTENSIONS_TO_BUILD environment variable and specifying a comma separated list of extension names.  
+For example, if you wish to build both the windows_sync_objects and fwctl extensions on Windows, you can set it to:
+```
+$env:TRAILOFBITS_EXTENSIONS_TO_BUILD = "windows_sync_objects,fwctl"
+```
+
 This is where the extension should be available once it has been built:
  * Windows: `osquery/build/windows10/external/Release/trailofbits_osquery_extensions.ext.exe`
  * Linux: `osquery/build/linux/external/trailofbits_osquery_extensions.ext`


### PR DESCRIPTION
Use TRAILOFBITS_EXTENSIONS_TO_BUILD environment variable
to specify a comma separated list of extensions.

This closes #35