### PR TITLE
network_monitor/dns_events: Add support for promiscuous mode

### DIFF
--- a/network_monitor/README.md
+++ b/network_monitor/README.md
@@ -9,12 +9,15 @@ The configuration file is located at the following path: `/var/osquery/extension
   "user": "tob_network_monitor_ext",
 
   "dns_events": {
-    "interface": "eth0"
+    "interface": "eth0",
+    "promiscuous": false
   }
 }
 ```
 
-The `user` setting is used when dropping privileges and is mandatory.
+**user**: This user will be used to drop privileges.
+**interface**: Interface to monitor. Currently, only one is supported.
+**promiscuous**: If enabled, the table will also be able to report DNS requests/answers from other machines on the same network. **You should always consult the network administrator when enabling this setting!**
 
 # Dropping privileges
 During startup, the extension will perform the following tasks:

--- a/network_monitor/src/pcap_utils.h
+++ b/network_monitor/src/pcap_utils.h
@@ -57,7 +57,8 @@ struct NetworkDeviceInformation final {
 osquery::Status createPcap(PcapRef& ref,
                            const std::string& device_name,
                            int capture_buffer_size,
-                           int packet_capture_timeout);
+                           int packet_capture_timeout,
+                           bool promiscuous_mode);
 
 /// Returns the device information for the specified network interface
 osquery::Status getNetworkDeviceInformation(NetworkDeviceInformation& dev_info,

--- a/network_monitor/src/pcapreaderservice.cpp
+++ b/network_monitor/src/pcapreaderservice.cpp
@@ -111,15 +111,29 @@ osquery::Status PcapReaderService::configure(
   if (interface_name_obj == json11::Json()) {
     LOG(ERROR)
         << "The 'interface' value is missing from the 'dns_events' section";
+
     return osquery::Status(0);
   }
 
   auto interface_name = interface_name_obj.string_value();
 
+  const auto& promiscuous_mode_obj = dns_event_configuration["promiscuous"];
+  if (promiscuous_mode_obj == json11::Json()) {
+    LOG(ERROR)
+        << "The 'promiscuous' value is missing from the 'dns_events' section";
+
+    return osquery::Status(0);
+  }
+
+  auto promiscuous_mode = promiscuous_mode_obj.bool_value();
+
   std::lock_guard<std::mutex> lock(pcap_mutex);
 
-  auto status = createPcap(
-      pcap, interface_name, kCaptureBufferSize, kCaptureBufferTimeout);
+  auto status = createPcap(pcap,
+                           interface_name,
+                           kCaptureBufferSize,
+                           kCaptureBufferTimeout,
+                           promiscuous_mode);
 
   if (!status.ok()) {
     return status;


### PR DESCRIPTION
This commit adds support for promiscuous capture; this is useful to
capture DNS requests/answers from/to other machines on the same
network, without installing osquery + extension on each machine.