### PR TITLE
fix iptables to get the entries from IP table

### DIFF
--- a/libraries/extutils/src/extutils.cpp
+++ b/libraries/extutils/src/extutils.cpp
@@ -51,6 +51,10 @@ bool ExecuteProcess(ProcessOutput& output,
 
     io_service.run();
 
+    // wait for the child process to get correct exit code
+    // https://www.boost.org/doc/libs/1_71_0/doc/html/boost/process/child.html#idm45477675646672-bb
+    process.wait();
+
     output.std_output = process_stdout.get();
     output.std_error = process_stderr.get();
     output.exit_code = process.exit_code();


### PR DESCRIPTION
### Requirements
ExecuteProcess gets the incorrect exit code causing the execution of system binary `iptables-save` to fail. 

### Description of the Change
ExecuteProcess waits for the child process before getting the exit code. The return value of `process.exit_code()` has no meaning before it. 