### PR TITLE
Fix the find_package() warning with 'curl'

### DIFF
--- a/efigy/CMakeLists.txt
+++ b/efigy/CMakeLists.txt
@@ -21,7 +21,7 @@ function(main)
     "-framework IOKit"
   )
 
-  find_package(curl REQUIRED)
+  find_package(CURL REQUIRED)
   list(APPEND project_libraries
     ${CURL_LIBRARIES}
   )


### PR DESCRIPTION
### Description of the Change

This small change fixes this warning:

```Importing extensions from '/Users/mmyers/Projects/Engineering/osquery/osquery/src/external/extension_trailofbits'
 > darwin_unified_log
 > efigy
CMake Warning (dev) at /usr/local/Cellar/cmake/3.18.4/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:273 (message):
  The package name passed to `find_package_handle_standard_args` (CURL) does
  not match the name of the calling package (curl).  This can lead to
  problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  /usr/local/Cellar/cmake/3.18.4/share/cmake/Modules/Findcurl.cmake:169 (find_package_handle_standard_args)
  external/extension_trailofbits/efigy/CMakeLists.txt:24 (find_package)
  external/extension_trailofbits/efigy/CMakeLists.txt:53 (main)
This warning is for project developers.  Use -Wno-dev to suppress it.
```