### PR TITLE
updated the network monitor extension to use runner.waitForShutdown()

### DIFF
--- a/network_monitor/src/main.cpp
+++ b/network_monitor/src/main.cpp
@@ -75,11 +75,7 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  // We can't use the runner.waitForShutdown() method because it calls exit()
-  osquery::Dispatcher::joinServices();
-  osquery::EventFactory::end(true);
-  GFLAGS_NAMESPACE::ShutDownCommandLineFlags();
-  osquery::shutdownDatabase();
+  runner.waitForShutdown();
 
   scheduler->stop();
   scheduler.reset();


### PR DESCRIPTION
### Requirements

No additional requirements beyond those needed to build the osquery extensions on linux.

### Description of the Change

In earlier versions of osquery, `runner.waitForShutdown()` invoked `exit()` in its body, making it unsuitable for extensions that needed to perform some final cleanup. `waitForShutdown()` has been updated, so its now appropriate to use, and cleans up the shutdown process of the network monitor.

### Applicable Issues

This addresses issue #62 
