### PR TITLE
fwctl: change 'blacklist' to 'denylist' in all instances

### DIFF
--- a/fwctl/CMakeLists.txt
+++ b/fwctl/CMakeLists.txt
@@ -27,17 +27,17 @@ function(fwctlMain)
     src/basetable.h
   )
 
-  addOsqueryExtensionEx("HostBlacklistTable" "table" "HostBlacklist"
-    SOURCES ${project_common_source_files} src/hostblacklist.h src/hostblacklist.cpp
+  addOsqueryExtensionEx("HostDenylistTable" "table" "HostDenylist"
+    SOURCES ${project_common_source_files} src/hostdenylist.h src/hostdenylist.cpp
     INCLUDEDIRS "${CMAKE_CURRENT_SOURCE_DIR}/src"
-    MAININCLUDES hostblacklist.h
+    MAININCLUDES hostdenylist.h
     LIBRARIES ${project_libraries}
   )
 
-  addOsqueryExtensionEx("PortBlacklistTable" "table" "PortBlacklist"
-    SOURCES ${project_common_source_files} src/portblacklist.h src/portblacklist.cpp
+  addOsqueryExtensionEx("PortDenylistTable" "table" "PortDenylist"
+    SOURCES ${project_common_source_files} src/portdenylist.h src/portdenylist.cpp
     INCLUDEDIRS "${CMAKE_CURRENT_SOURCE_DIR}/src"
-    MAININCLUDES portblacklist.h
+    MAININCLUDES portdenylist.h
     LIBRARIES ${project_libraries}
   )
 
@@ -46,18 +46,18 @@ function(fwctlMain)
     set(project_test_files
 
       tests/main.cpp
-      tests/hostblacklist.cpp
+      tests/hostdenylist.cpp
 
       src/globals.h
       src/globals.cpp
 
       src/basetable.h
 
-      src/hostblacklist.h
-      src/hostblacklist.cpp
+      src/hostdenylist.h
+      src/hostdenylist.cpp
 
-      src/portblacklist.h
-      src/portblacklist.cpp
+      src/portdenylist.h
+      src/portdenylist.cpp
     )
 
     AddTest("tables" test_target_name ${project_test_files})

--- a/fwctl/src/hostdenylist.h
+++ b/fwctl/src/hostdenylist.h
@@ -31,10 +31,10 @@ struct HostRule final {
 
 using HostRuleMap = std::unordered_map<PrimaryKey, HostRule>;
 
-class HostBlacklistTable final : public BaseTable {
+class HostDenylistTable final : public BaseTable {
  public:
-  HostBlacklistTable();
-  virtual ~HostBlacklistTable();
+  HostDenylistTable();
+  virtual ~HostDenylistTable();
 
   osquery::TableColumns columns() const;
 
@@ -75,4 +75,4 @@ class HostBlacklistTable final : public BaseTable {
 } // namespace trailofbits
 
 // Export the class outside the namespace so that osquery can pick it up
-using HostBlacklistTable = trailofbits::HostBlacklistTable;
+using HostDenylistTable = trailofbits::HostDenylistTable;

--- a/fwctl/src/portdenylist.h
+++ b/fwctl/src/portdenylist.h
@@ -31,10 +31,10 @@ struct PortRule final {
 
 using PortRuleMap = std::unordered_map<PrimaryKey, PortRule>;
 
-class PortBlacklistTable final : public BaseTable {
+class PortDenylistTable final : public BaseTable {
  public:
-  PortBlacklistTable();
-  virtual ~PortBlacklistTable();
+  PortDenylistTable();
+  virtual ~PortDenylistTable();
 
   osquery::TableColumns columns() const;
 
@@ -74,4 +74,4 @@ class PortBlacklistTable final : public BaseTable {
 } // namespace trailofbits
 
 // Export the class outside the namespace so that osquery can pick it up
-using PortBlacklistTable = trailofbits::PortBlacklistTable;
+using PortDenylistTable = trailofbits::PortDenylistTable;

--- a/fwctl/tests/hostdenylist.cpp
+++ b/fwctl/tests/hostdenylist.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "hostblacklist.h"
+#include "hostdenylist.h"
 
 #include <sstream>
 
@@ -29,10 +29,10 @@ const std::string ipv6_localhost = "localhost";
 const std::string ipv6_localhost = "localhost";
 #endif
 
-TEST(HostBlacklistTests, DomainResolution) {
+TEST(HostDenylistTests, DomainResolution) {
   std::string ipv4_address;
   auto status =
-      HostBlacklistTable::DomainToAddress(ipv4_address, "localhost", true);
+      HostDenylistTable::DomainToAddress(ipv4_address, "localhost", true);
 
   EXPECT_TRUE(status.ok());
   if (status.ok()) {
@@ -42,22 +42,22 @@ TEST(HostBlacklistTests, DomainResolution) {
   // ipv6 may not be available here
   std::string ipv6_address;
   status =
-      HostBlacklistTable::DomainToAddress(ipv6_address, "localhost", false);
+      HostDenylistTable::DomainToAddress(ipv6_address, "localhost", false);
   if (status.ok()) {
     EXPECT_EQ(ipv6_address, "::1");
   }
 }
 
-TEST(HostBlacklistTests, ReverseLookup) {
+TEST(HostDenylistTests, ReverseLookup) {
   std::string domain;
-  auto status = HostBlacklistTable::AddressToDomain(domain, "127.0.0.1");
+  auto status = HostDenylistTable::AddressToDomain(domain, "127.0.0.1");
 
   EXPECT_TRUE(status.ok());
   if (status.ok()) {
     EXPECT_EQ(domain, "localhost");
   }
 
-  status = HostBlacklistTable::AddressToDomain(domain, "::1");
+  status = HostDenylistTable::AddressToDomain(domain, "::1");
 
   EXPECT_TRUE(status.ok());
   if (status.ok()) {

--- a/libraries/firewall/include/trailofbits/ifirewall.h
+++ b/libraries/firewall/include/trailofbits/ifirewall.h
@@ -45,25 +45,25 @@ class IFirewall : private boost::noncopyable {
 
   virtual ~IFirewall() = default;
 
-  virtual Status addPortToBlacklist(std::uint16_t port,
+  virtual Status addPortToDenylist(std::uint16_t port,
                                     TrafficDirection direction,
                                     Protocol protocol) = 0;
 
-  virtual Status removePortFromBlacklist(std::uint16_t port,
+  virtual Status removePortFromDenylist(std::uint16_t port,
                                          TrafficDirection direction,
                                          Protocol protocol) = 0;
 
-  virtual Status enumerateBlacklistedPorts(
+  virtual Status enumerateDenylistedPorts(
       bool (*callback)(std::uint16_t port,
                        TrafficDirection direction,
                        Protocol protocol,
                        void* user_defined),
       void* user_defined) = 0;
 
-  virtual Status addHostToBlacklist(const std::string& host) = 0;
-  virtual Status removeHostFromBlacklist(const std::string& host) = 0;
+  virtual Status addHostToDenylist(const std::string& host) = 0;
+  virtual Status removeHostFromDenylist(const std::string& host) = 0;
 
-  virtual Status enumerateBlacklistedHosts(
+  virtual Status enumerateDenylistedHosts(
       bool (*callback)(const std::string& host, void* user_defined),
       void* user_defined) = 0;
 };

--- a/libraries/firewall/linux/src/firewall.cpp
+++ b/libraries/firewall/linux/src/firewall.cpp
@@ -47,7 +47,7 @@ Firewall::Status Firewall::create(std::unique_ptr<IFirewall>& obj) {
 
 Firewall::~Firewall() {}
 
-Firewall::Status Firewall::addPortToBlacklist(
+Firewall::Status Firewall::addPortToDenylist(
     std::uint16_t port,
     Firewall::TrafficDirection direction,
     Firewall::Protocol protocol) {
@@ -106,7 +106,7 @@ Firewall::Status Firewall::addPortToBlacklist(
   return Status(true);
 }
 
-Firewall::Status Firewall::removePortFromBlacklist(
+Firewall::Status Firewall::removePortFromDenylist(
     std::uint16_t port,
     Firewall::TrafficDirection direction,
     Firewall::Protocol protocol) {
@@ -165,7 +165,7 @@ Firewall::Status Firewall::removePortFromBlacklist(
   return Status(true);
 }
 
-Firewall::Status Firewall::enumerateBlacklistedPorts(
+Firewall::Status Firewall::enumerateDenylistedPorts(
     bool (*callback)(std::uint16_t port,
                      Firewall::TrafficDirection direction,
                      Firewall::Protocol protocol,
@@ -195,7 +195,7 @@ Firewall::Status Firewall::enumerateBlacklistedPorts(
   return Status(true);
 }
 
-Firewall::Status Firewall::addHostToBlacklist(const std::string& host) {
+Firewall::Status Firewall::addHostToDenylist(const std::string& host) {
   std::lock_guard<std::mutex> lock(d->mutex);
 
   std::string firewall_state;
@@ -229,7 +229,7 @@ Firewall::Status Firewall::addHostToBlacklist(const std::string& host) {
   return Status(true);
 }
 
-Firewall::Status Firewall::removeHostFromBlacklist(const std::string& host) {
+Firewall::Status Firewall::removeHostFromDenylist(const std::string& host) {
   std::lock_guard<std::mutex> lock(d->mutex);
 
   std::string firewall_state;
@@ -263,7 +263,7 @@ Firewall::Status Firewall::removeHostFromBlacklist(const std::string& host) {
   return Status(true);
 }
 
-Firewall::Status Firewall::enumerateBlacklistedHosts(
+Firewall::Status Firewall::enumerateDenylistedHosts(
     bool (*callback)(const std::string& host, void* user_defined),
     void* user_defined) {
   std::vector<PortRule> port_rules;

--- a/libraries/firewall/linux/src/firewall.h
+++ b/libraries/firewall/linux/src/firewall.h
@@ -29,25 +29,25 @@ class Firewall final : public IFirewall {
   static Status create(std::unique_ptr<IFirewall>& obj);
   virtual ~Firewall();
 
-  virtual Status addPortToBlacklist(std::uint16_t port,
+  virtual Status addPortToDenylist(std::uint16_t port,
                                     TrafficDirection direction,
                                     Protocol protocol) override;
 
-  virtual Status removePortFromBlacklist(std::uint16_t port,
+  virtual Status removePortFromDenylist(std::uint16_t port,
                                          TrafficDirection direction,
                                          Protocol protocol) override;
 
-  virtual Status enumerateBlacklistedPorts(
+  virtual Status enumerateDenylistedPorts(
       bool (*callback)(std::uint16_t port,
                        TrafficDirection direction,
                        Protocol protocol,
                        void* user_defined),
       void* user_defined) override;
 
-  virtual Status addHostToBlacklist(const std::string& host) override;
-  virtual Status removeHostFromBlacklist(const std::string& host) override;
+  virtual Status addHostToDenylist(const std::string& host) override;
+  virtual Status removeHostFromDenylist(const std::string& host) override;
 
-  virtual Status enumerateBlacklistedHosts(
+  virtual Status enumerateDenylistedHosts(
       bool (*callback)(const std::string& host, void* user_defined),
       void* user_defined) override;
 

--- a/libraries/firewall/macos/src/firewall.cpp
+++ b/libraries/firewall/macos/src/firewall.cpp
@@ -58,7 +58,7 @@ Firewall::~Firewall() {
   static_cast<void>(status);
 }
 
-Firewall::Status Firewall::addPortToBlacklist(
+Firewall::Status Firewall::addPortToDenylist(
     std::uint16_t port,
     Firewall::TrafficDirection direction,
     Firewall::Protocol protocol) {
@@ -98,7 +98,7 @@ Firewall::Status Firewall::addPortToBlacklist(
   return applyNewFirewallRules(port_rules, host_rules);
 }
 
-Firewall::Status Firewall::removePortFromBlacklist(
+Firewall::Status Firewall::removePortFromDenylist(
     std::uint16_t port,
     Firewall::TrafficDirection direction,
     Firewall::Protocol protocol) {
@@ -137,7 +137,7 @@ Firewall::Status Firewall::removePortFromBlacklist(
   return applyNewFirewallRules(port_rules, host_rules);
 }
 
-Firewall::Status Firewall::enumerateBlacklistedPorts(
+Firewall::Status Firewall::enumerateDenylistedPorts(
     bool (*callback)(std::uint16_t port,
                      Firewall::TrafficDirection direction,
                      Firewall::Protocol protocol,
@@ -167,7 +167,7 @@ Firewall::Status Firewall::enumerateBlacklistedPorts(
   return Status(true);
 }
 
-Firewall::Status Firewall::addHostToBlacklist(const std::string &host) {
+Firewall::Status Firewall::addHostToDenylist(const std::string &host) {
   std::lock_guard<std::mutex> lock(d->mutex);
 
   std::vector<PortRule> port_rules;
@@ -186,7 +186,7 @@ Firewall::Status Firewall::addHostToBlacklist(const std::string &host) {
   return applyNewFirewallRules(port_rules, host_rules);
 }
 
-Firewall::Status Firewall::removeHostFromBlacklist(const std::string &host) {
+Firewall::Status Firewall::removeHostFromDenylist(const std::string &host) {
   std::lock_guard<std::mutex> lock(d->mutex);
 
   std::vector<PortRule> port_rules;
@@ -207,7 +207,7 @@ Firewall::Status Firewall::removeHostFromBlacklist(const std::string &host) {
   return applyNewFirewallRules(port_rules, host_rules);
 }
 
-Firewall::Status Firewall::enumerateBlacklistedHosts(
+Firewall::Status Firewall::enumerateDenylistedHosts(
       bool (*callback)(const std::string& host, void* user_defined),
       void* user_defined) {
   std::vector<PortRule> port_rules;
@@ -256,16 +256,16 @@ Firewall::Status Firewall::readFirewallState(std::vector<PortRule> &port_rules, 
 
   ParsePortRulesFromAnchor(anchor_rules, port_rules);
 
-  if (IsHostBlacklistTableActive(anchor_rules, blocked_hosts_table)) {
-    std::string blacklist_table_contents;
+  if (IsHostDenylistTableActive(anchor_rules, blocked_hosts_table)) {
+    std::string denylist_table_contents;
     status =
-        ReadTable(blacklist_table_contents, primary_anchor, blocked_hosts_table);
+        ReadTable(denylist_table_contents, primary_anchor, blocked_hosts_table);
 
     if (!status.success()) {
       return status;
     }
 
-    ParseTable(blacklist_table_contents, host_rules);
+    ParseTable(denylist_table_contents, host_rules);
   }
 
   return Status(true);
@@ -512,7 +512,7 @@ void Firewall::ParsePortRulesFromAnchor(
   }
 }
 
-bool Firewall::IsHostBlacklistTableActive(const std::string& contents,
+bool Firewall::IsHostDenylistTableActive(const std::string& contents,
                                           const std::string& table) {
   /*
     Host rules - using tables

--- a/libraries/firewall/macos/src/firewall.h
+++ b/libraries/firewall/macos/src/firewall.h
@@ -27,25 +27,25 @@ class Firewall final : public IFirewall {
   static Status create(std::unique_ptr<IFirewall>& obj);
   virtual ~Firewall();
 
-  virtual Status addPortToBlacklist(std::uint16_t port,
+  virtual Status addPortToDenylist(std::uint16_t port,
                                     TrafficDirection direction,
                                     Protocol protocol) override;
 
-  virtual Status removePortFromBlacklist(std::uint16_t port,
+  virtual Status removePortFromDenylist(std::uint16_t port,
                                          TrafficDirection direction,
                                          Protocol protocol) override;
 
-  virtual Status enumerateBlacklistedPorts(
+  virtual Status enumerateDenylistedPorts(
       bool (*callback)(std::uint16_t port,
                        TrafficDirection direction,
                        Protocol protocol,
                        void* user_defined),
       void* user_defined) override;
 
-  virtual Status addHostToBlacklist(const std::string& host) override;
-  virtual Status removeHostFromBlacklist(const std::string& host) override;
+  virtual Status addHostToDenylist(const std::string& host) override;
+  virtual Status removeHostFromDenylist(const std::string& host) override;
 
-  virtual Status enumerateBlacklistedHosts(
+  virtual Status enumerateDenylistedHosts(
       bool (*callback)(const std::string& host, void* user_defined),
       void* user_defined) override;
 
@@ -92,7 +92,7 @@ class Firewall final : public IFirewall {
                           const std::string& anchor,
                           const std::string& table);
 
-  static bool IsHostBlacklistTableActive(const std::string& contents,
+  static bool IsHostDenylistTableActive(const std::string& contents,
                                          const std::string& table);
 
  private:

--- a/libraries/firewall/windows/src/firewall.cpp
+++ b/libraries/firewall/windows/src/firewall.cpp
@@ -59,7 +59,7 @@ Firewall::Status Firewall::create(std::unique_ptr<IFirewall>& obj) {
 
 Firewall::~Firewall() {}
 
-Firewall::Status Firewall::addPortToBlacklist(
+Firewall::Status Firewall::addPortToDenylist(
     std::uint16_t port,
     Firewall::TrafficDirection direction,
     Firewall::Protocol protocol) {
@@ -126,7 +126,7 @@ Firewall::Status Firewall::addPortToBlacklist(
   return Status(true);
 }
 
-Firewall::Status Firewall::removePortFromBlacklist(
+Firewall::Status Firewall::removePortFromDenylist(
     std::uint16_t port,
     Firewall::TrafficDirection direction,
     Firewall::Protocol protocol) {
@@ -208,7 +208,7 @@ void Firewall::getHostBlockRuleNames(const std::string& state,
   }
 }
 
-Firewall::Status Firewall::removeHostFromBlacklist(const std::string& host) {
+Firewall::Status Firewall::removeHostFromDenylist(const std::string& host) {
   std::lock_guard<std::mutex> lock(d->mutex);
 
   std::string firewall_state;
@@ -243,7 +243,7 @@ Firewall::Status Firewall::removeHostFromBlacklist(const std::string& host) {
   return Status(true);
 }
 
-Firewall::Status Firewall::enumerateBlacklistedHosts(
+Firewall::Status Firewall::enumerateDenylistedHosts(
     bool (*callback)(const std::string& host, void* user_defined),
     void* user_defined) {
   std::vector<PortRule> port_rules;
@@ -356,7 +356,7 @@ void Firewall::ParseFirewallState(std::vector<PortRule>& port_rules,
   }
 }
 
-Firewall::Status Firewall::enumerateBlacklistedPorts(
+Firewall::Status Firewall::enumerateDenylistedPorts(
     bool (*callback)(std::uint16_t port,
                      Firewall::TrafficDirection direction,
                      Firewall::Protocol protocol,
@@ -386,7 +386,7 @@ Firewall::Status Firewall::enumerateBlacklistedPorts(
   return Status(true);
 }
 
-Firewall::Status Firewall::addHostToBlacklist(const std::string& host) {
+Firewall::Status Firewall::addHostToDenylist(const std::string& host) {
   std::lock_guard<std::mutex> lock(d->mutex);
 
   std::string firewall_state;

--- a/libraries/firewall/windows/src/firewall.h
+++ b/libraries/firewall/windows/src/firewall.h
@@ -15,25 +15,25 @@ class Firewall final : public IFirewall {
   static Status create(std::unique_ptr<IFirewall>& obj);
   virtual ~Firewall();
 
-  virtual Status addPortToBlacklist(std::uint16_t port,
+  virtual Status addPortToDenylist(std::uint16_t port,
                                     TrafficDirection direction,
                                     Protocol protocol) override;
 
-  virtual Status removePortFromBlacklist(std::uint16_t port,
+  virtual Status removePortFromDenylist(std::uint16_t port,
                                          TrafficDirection direction,
                                          Protocol protocol) override;
 
-  virtual Status enumerateBlacklistedPorts(
+  virtual Status enumerateDenylistedPorts(
       bool (*callback)(std::uint16_t port,
                        TrafficDirection direction,
                        Protocol protocol,
                        void* user_defined),
       void* user_defined) override;
 
-  virtual Status addHostToBlacklist(const std::string& host) override;
-  virtual Status removeHostFromBlacklist(const std::string& host) override;
+  virtual Status addHostToDenylist(const std::string& host) override;
+  virtual Status removeHostFromDenylist(const std::string& host) override;
 
-  virtual Status enumerateBlacklistedHosts(
+  virtual Status enumerateDenylistedHosts(
       bool (*callback)(const std::string& host, void* user_defined),
       void* user_defined) override;
 


### PR DESCRIPTION
### Requirements

### Description of the Change

Following [osquery's lead](https://github.com/osquery/osquery/issues/6475), this PR replaces problematic terminology.

### Alternate Designs

n/a

### Why Shouldn't This Be In oquery Core?

n/a

### Benefits

Signals that we don't wish to use language that some might see as racialized.

### Possible Drawbacks

This changes the name of the tables, which would break compatibility with queries that reference the tables by their old names. If these were tables in core, with `.table` spec files, we could alias them by the old names, e.g., `table_name("HostDenylist", aliases=["HostBlacklist"])`. But as extensions, their tables' names are defined with a call to the `REGISTER_EXTERNAL` macro. Again, we _could_ set an alias here in the `table_name` parameter if we were calling that SDK macro directly. But we've wrapped it in another macro that sets `table_name` to the C++ `TablePlugin` object name (or is it `BaseTable`?) and this approach doesn't allow for aliases.

### Verification Process

I built on Windows and ran some test queries, but really this just changes the table names.

### Applicable Issues

n/a